### PR TITLE
Fixing the link to RStans CRAN page

### DIFF
--- a/mc-stan.org/rstan.html
+++ b/mc-stan.org/rstan.html
@@ -82,7 +82,7 @@ Gelman et al." />
   from CRAN (the comprehensive R archive network):</p>
   <ul>
     <li> <i><a class="external"
-    href="https://cran.r-project.org/web/packages/rstan/rstan.pdf">RStan
+    href="https://cran.r-project.org/web/packages/rstan/index.html">RStan
     Distribution Page</a></i> <img
     class="external" src="external-link.png" alt="external link
     marker"/><span class="note">(CRAN)</span></li>


### PR DESCRIPTION
Currently the link on the RStan page points to RStans pdf-manual, while the link text states that it points to RStans CRAN page (which I think is more usefull). This changes the link to point to RStans CRAN page.